### PR TITLE
fix waf plugin document the parsing-ip-and-host wrong link

### DIFF
--- a/content/zh/projects/soul/waf-plugin/index.md
+++ b/content/zh/projects/soul/waf-plugin/index.md
@@ -47,4 +47,4 @@ description: waf插件
 
 * 当面对重放攻击时，你可以根据ip或者host来进行匹配，拦截掉非法的ip与host，设置reject策略。
 
-* 关于如何确定 ip 与 host 值，请看[ip与host](dev-iphost.md)
+* 关于如何确定 ip 与 host 值，请看 [parsing-ip-and-host](../custom-parsing-ip-and-host)


### PR DESCRIPTION
fix waf plugin document the parsing-ip-and-host wrong link